### PR TITLE
refactor: Amended FITSBlock.header type to FITSHeader[] in @observerly/fits.

### DIFF
--- a/src/header/__tests__/parseFITSHeaderBlock.spec.ts
+++ b/src/header/__tests__/parseFITSHeaderBlock.spec.ts
@@ -8,7 +8,7 @@
 
 import { describe, expect, it, suite } from 'vitest'
 
-import { parseFITSHeaderBlock } from '../'
+import { parseFITSHeaderBlock } from '..'
 
 /*****************************************************************************************************************/
 

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -6,6 +6,10 @@
 
 /*****************************************************************************************************************/
 
+import { type FITSHeader } from '../types'
+
+/*****************************************************************************************************************/
+
 export interface FITSBlock {
   /**
    *
@@ -24,7 +28,7 @@ export interface FITSBlock {
    * The ArrayBuffer as a raw parsed array of strings
    *
    */
-  headers: string[]
+  headers: FITSHeader[]
   /**
    *
    *


### PR DESCRIPTION
refactor: Amended FITSBlock.header type to FITSHeader[] in @observerly/fits.