### PR TITLE
fix: amend parseFITSHeaderRow to correctly parse booleans in @observerly/fits

### DIFF
--- a/src/header/parseFITSHeaderRow.ts
+++ b/src/header/parseFITSHeaderRow.ts
@@ -56,7 +56,7 @@ export const parseFITSHeaderRow = (line: string): FITSHeader => {
   }
 
   if (v.length === 1 && ['T', 'F'].includes(v)) {
-    value = 'T' ? true : false
+    value = v === 'T' ? true : false
   }
 
   const comment = c ? c.trim() : ''


### PR DESCRIPTION
fix: amend parseFITSHeaderRow to correctly parse booleans in @observerly/fits